### PR TITLE
Add support for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 22
+        versionCode 1
+        versionName "1.0"
+    }
+    
+    lintOptions {
+        warning 'InvalidPackage'
+    }
+}
+
+dependencies {
+    compile 'com.facebook.react:react-native:+'
+    compile 'com.yandex.android:mobmetricalib:2.76'
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.aandrosov.AppMetrica">
+
+</manifest>

--- a/android/src/main/java/com/aandrosov/AppMetrica/AppMetricaModule.java
+++ b/android/src/main/java/com/aandrosov/AppMetrica/AppMetricaModule.java
@@ -1,0 +1,92 @@
+package com.aandrosov.AppMetrica;
+
+import android.app.Activity;
+import android.app.Application;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.lang.Exception;
+
+import org.json.JSONObject;
+
+import com.yandex.metrica.YandexMetrica;
+
+public class AppMetricaModule extends ReactContextBaseJavaModule {
+    final static String ModuleName = "AppMetrica";
+
+    public AppMetricaModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return ModuleName;
+    }
+
+
+    @ReactMethod
+    public void activateWithApiKey(String key) {
+        YandexMetrica.activate(getReactApplicationContext().getApplicationContext(), key);
+
+        Activity activity = getCurrentActivity();
+        Application application = activity.getApplication();
+        YandexMetrica.enableActivityAutoTracking(application);
+    }
+
+    @ReactMethod
+    public void reportEvent(String message, @Nullable ReadableMap params) {
+        if (params != null) {
+            YandexMetrica.reportEvent(message, convertReadableMapToJson(params));
+        } else {
+            YandexMetrica.reportEvent(message);
+        }
+    }
+
+    private String convertReadableMapToJson(final ReadableMap readableMap) {
+		ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+        JSONObject json = new JSONObject();
+
+        try {
+            while (iterator.hasNextKey()) {
+                String key = iterator.nextKey();
+
+                switch (readableMap.getType(key)) {
+                    case Null:
+                        json.put(key, null);
+                        break;
+                    case Boolean:
+                        json.put(key, readableMap.getBoolean(key));
+                        break;
+                    case Number:
+                        json.put(key, readableMap.getDouble(key));
+                        break;
+                    case String:
+                        json.put(key, readableMap.getString(key));
+                        break;
+                    case Array:
+                        json.put(key, readableMap.getArray(key));
+                        break;
+                    case Map:
+                        json.put(key, convertReadableMapToJson(readableMap.getMap(key)));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        } catch (Exception ex) {
+            Log.d(ModuleName, "convertReadableMapToJson fail: " + ex);
+        }
+
+        return json.toString();
+    }
+}

--- a/android/src/main/java/com/aandrosov/AppMetrica/AppMetricaPackage.java
+++ b/android/src/main/java/com/aandrosov/AppMetrica/AppMetricaPackage.java
@@ -1,0 +1,25 @@
+package com.aandrosov.AppMetrica;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AppMetricaPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+      return Arrays.<NativeModule>asList(
+          new AppMetricaModule(reactContext)
+      );
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
Это работает, события отправляются, хотя отображаются не сразу, в связи с этим я не уверен насчет правильности работы модуля, имею в виду метод `enableActivityAutoTracking();`. Про него написано: 

> Данный метод необходимо вызвать сразу после инициализации библиотеки AppMetrica до открытия первого экрана приложения

И получается что он будет вызван с открытием первого экрана, что не верно? Это мой первый модуль для RN, решил попробовать, поэтому не особо в курсе, и не нашёл события типа `onCreate` или `onInit` для модуля, чтобы этот метод можно было вызвать до инициализации модуля. Думал в конструкторе модуля вызвать его, но там нету активити. Либо значит нужно вручную в MainActivity приложения вызывать его, но хотелось чтобы автоматически это было при подключении (`npm link`)... Надеюсь хоть так помог.