### PR TITLE
Bump Android mobmetricalib to 2.80

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,5 +18,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.yandex.android:mobmetricalib:2.76'
+    compile 'com.yandex.android:mobmetricalib:2.80'
 }


### PR DESCRIPTION
fixes Android 8 support, see

https://github.com/yandexmobile/metrica-sdk-android/issues/42