### PR TITLE
Allow Cocoapods

### DIFF
--- a/ios/RCTAppMetrica/RCTAppMetrica.xcodeproj/project.pbxproj
+++ b/ios/RCTAppMetrica/RCTAppMetrica.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../../ios",
 					"$(PROJECT_DIR)/../../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../../ios/Pods/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../../ios/Pods/**",
@@ -242,6 +243,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../../ios",
 					"$(PROJECT_DIR)/../../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../../ios/Pods/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../../ios/Pods/**",


### PR DESCRIPTION
Building fails when AppMetrica installed using Cocoapods. This PR updates Xcode project to include Pods directory to be able to find the framework.