### PR TITLE
Add activation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ import AppMetrica from 'react-native-appmetrica';
 
 // Starts the statistics collection process.
 AppMetrica.activateWithApiKey('...KEY...');
+// OR
+AppMetrica.activateWithConfig({
+  apiKey: '...KEY...',
+  sessionTimeout: 120,
+  firstActivationAsUpdate: true,
+});
 
 // Sends a custom event message and additional parameters (optional).
 AppMetrica.reportEvent('My event');

--- a/android/src/main/java/com/doochik/RNAppMetrica/AppMetricaModule.java
+++ b/android/src/main/java/com/doochik/RNAppMetrica/AppMetricaModule.java
@@ -43,6 +43,23 @@ public class AppMetricaModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void activateWithConfig(ReadableMap params) {
+        YandexMetricaConfig.Builder configBuilder = YandexMetricaConfig.newConfigBuilder(params.getString("apiKey"));
+        if (params.hasKey("sessionTimeout")) {
+            configBuilder.withSessionTimeout(params.getInt("sessionTimeout"));
+        }
+        if (params.hasKey("firstActivationAsUpdate")) {
+            configBuilder.handleFirstActivationAsUpdate(params.getBoolean("firstActivationAsUpdate"));
+        }
+        YandexMetrica.activate(getReactApplicationContext().getApplicationContext(), configBuilder.build());
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            Application application = activity.getApplication();
+            YandexMetrica.enableActivityAutoTracking(application);
+        }
+    }
+
+    @ReactMethod
     public void reportError(String message) {
         try {
             Integer.valueOf("00xffWr0ng");

--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@
 import { NativeModules } from 'react-native';
 const { AppMetrica } = NativeModules;
 
+type ActivationConfig = {
+    apiKey: string,
+    sessionTimeout?: number,
+    firstActivationAsUpdate?: boolean,
+};
+
 export default {
 
     /**
@@ -11,6 +17,14 @@ export default {
      */
     activateWithApiKey(apiKey: string) {
         AppMetrica.activateWithApiKey(apiKey);
+    },
+
+    /**
+     * Starts the statistics collection process using config.
+     * @param {object} params
+     */
+    activateWithConfig(params: ActivationConfig) {
+        AppMetrica.activateWithConfig(params);
     },
 
     /**

--- a/ios/RCTAppMetrica/RCTAppMetrica/RCTAppMetrica.m
+++ b/ios/RCTAppMetrica/RCTAppMetrica/RCTAppMetrica.m
@@ -2,7 +2,7 @@
 #import <YandexMobileMetrica/YandexMobileMetrica.h>
 
 @implementation RCTAppMetrica {
-    
+
 }
 
 RCT_EXPORT_MODULE();
@@ -10,6 +10,17 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(activateWithApiKey:(NSString *)apiKey)
 {
     YMMYandexMetricaConfiguration *configuration = [[YMMYandexMetricaConfiguration alloc] initWithApiKey:apiKey];
+    [YMMYandexMetrica activateWithConfiguration:configuration];
+}
+
+RCT_EXPORT_METHOD(activateWithConfig:(NSDictionary *)config) {
+    YMMYandexMetricaConfiguration *configuration = [[YMMYandexMetricaConfiguration alloc] initWithApiKey:config[@"apiKey"]];
+    if (config[@"sessionTimeout"] != (id)[NSNull null]) {
+        [configuration setSessionTimeout:[config[@"sessionTimeout"] intValue]];
+    }
+    if (config[@"firstActivationAsUpdate"] != (id)[NSNull null]) {
+        [configuration setHandleFirstActivationAsUpdate:[config[@"firstActivationAsUpdate"] boolValue]];
+    }
     [YMMYandexMetrica activateWithConfiguration:configuration];
 }
 


### PR DESCRIPTION
This PR introduces a method to activate AppMetrica with extra configs.
`apiKey`, `sessionTimeout`, `firstActivationAsUpdate` fields are supported for now.